### PR TITLE
async -> async_ to be compatible with python 3.7

### DIFF
--- a/pythonx/cm.py
+++ b/pythonx/cm.py
@@ -148,7 +148,7 @@ class Base:
     def complete(self, name, ctx, startcol, matches, refresh=False):
         if isinstance(name,dict):
             name = name['name']
-        self.nvim.call('cm#complete', name, ctx, startcol, matches, refresh, async=True)
+        self.nvim.call('cm#complete', name, ctx, startcol, matches, refresh, async_=True)
 
     def snippet_placeholder(self, num, txt=''):
         # TODO: this version is so simple, but I haven't met those complicated
@@ -219,7 +219,7 @@ def start_and_run_channel(channel_type, serveraddr, source_name, modulename):
                 m = importlib.reload(m)
 
         handler = m.Source(nvim)
-        nvim.call('cm#_channel_started',source_name, nvim.channel_id, async=True)
+        nvim.call('cm#_channel_started',source_name, nvim.channel_id, async_=True)
         logger.info('<%s> handler created, entering event loop', source_name)
 
 

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -49,7 +49,7 @@ class CoreHandler(cm.Base):
 
         # after all sources are registered, so that all channels will be
         # started the first time cm_start_channels is called
-        self.nvim.call('cm#_core_channel_started', self.nvim.channel_id, async=True)
+        self.nvim.call('cm#_core_channel_started', self.nvim.channel_id, async_=True)
 
         # load configurations
         self._servername = self.nvim.vars['_cm_servername']
@@ -133,7 +133,7 @@ class CoreHandler(cm.Base):
                     source[k] = kwargs[k]
 
                 logger.info('registering source: %s',source)
-                self.nvim.call('cm#register_source', source, async=True)
+                self.nvim.call('cm#register_source', source, async_=True)
 
                 # use a trick to only register the source withou loading the entire
                 # module
@@ -375,7 +375,7 @@ class CoreHandler(cm.Base):
         else:
             logger.info('notify_sources_to_refresh calls cnt [%s], channels cnt [%s]',len(refreshes_calls),len(refreshes_channels))
             logger.debug('cm#_notify_sources_to_refresh [%s] [%s] [%s]', [e['name'] for e in refreshes_calls], [e['name'] for e in refreshes_channels], root_ctx)
-            self.nvim.call('cm#_notify_sources_to_refresh', refreshes_calls, refreshes_channels, root_ctx, async=True)
+            self.nvim.call('cm#_notify_sources_to_refresh', refreshes_calls, refreshes_channels, root_ctx, async_=True)
 
             # complete delay timer
             def on_timeout():


### PR DESCRIPTION
`async` is a keyword in python 3.7

    >>> import keyword
    >>> keyword.iskeyword('async')
    True

Trying to use it as a kwarg now results in a syntax error. [Luckily in
newer versions of nvim](https://github.com/neovim/python-client/blob/0.2.6/neovim/api/nvim.py#L155), it expects `async_` instead of `async`.